### PR TITLE
CircleCI extra requirements completed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,6 @@ jobs:
             cd ~/blogtozip/beats
             sudo hugo 
       - run:
-          command: hugo check
-      - run:
           command : |
             tar -zcvf $CIRCLE_SHA1.tar.gz ~/blogtozip/beats/public
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
             sudo hugo 
       - run:
           command : |
-            tar -r $CIRCLE_SHA1.tar.gz ~/blogtozip/beats/public
+            tar -zcvf $CIRCLE_SHA1.tar.gz ~/blogtozip/beats/public
       - run:
          command: ls
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,11 +36,11 @@ jobs:
             cd ~/project/
             sudo mv -v * ~/blogtozip/beats/content/post
       - run:
-          command: ls
-      - run:
           command: |
             cd ~/blogtozip/beats
             sudo hugo 
+      - run:
+          command: hugo check
       - run:
           command : |
             tar -zcvf $CIRCLE_SHA1.tar.gz ~/blogtozip/beats/public

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
             sudo hugo 
       - run:
           command : |
-            zip -r zipfile.zip ~/blogtozip/beats/public
+            tar -r $CIRCLE_SHA1.tar.gz ~/blogtozip/beats/public
       - run:
          command: ls
       - run:


### PR DESCRIPTION
Still need the AWS user to upload to s3, you can use $CIRCLE_SHA1 to get the SHA of the commit for future reference (will have to do this when we upload the .tar.gz folder to s3)

Extra reqs completed :
- change .zip to .tar.gz
- get the sha1 of the commit
- rename file <sha1>.tar.gz