### PR TITLE
Refactored dockerfiles for a smaller image

### DIFF
--- a/fa480.club-dockerfile/Dockerfile
+++ b/fa480.club-dockerfile/Dockerfile
@@ -6,11 +6,6 @@ FROM ubuntu:14.04.5
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
 # Installing minimum software to get the website running.
-RUN apt-get update
-RUN apt-get install -y apache2
-RUN apt-get install -y curl
-RUN apt-get install -y dpkg
-RUN apt-get install -y git
-RUN apt-get install -y python-pip
-RUN apt-get install -y wget
-RUN apt-get install -y rcconf && update-rc.d -f apache2 remove && update-rc.d -f apache2 defaults
+RUN apt-get update && \
+apt-get install --no-install-recommends -y apache2 curl dpkg git python-pip wget && \
+rm -rf /var/lib/apt/lists/*

--- a/production-site-dockerfile/Dockerfile
+++ b/production-site-dockerfile/Dockerfile
@@ -8,54 +8,53 @@ FROM fa480.club-base
 # Do not include the [ ] around the imageid.
 
 # Installing Hugo
-RUN wget https://github.com/gohugoio/hugo/releases/download/v0.49/hugo_0.49_Linux-64bit.deb
-RUN dpkg -i hugo_0.49_Linux-64bit.deb
-RUN pip install awscli --upgrade --user
+RUN wget https://github.com/gohugoio/hugo/releases/download/v0.49/hugo_0.49_Linux-64bit.deb && \
+dpkg -i hugo_0.49_Linux-64bit.deb && \
+rm hugo_0.49_Linux-64bit.deb && \
+pip install awscli --upgrade --user
 
 # Get the website from github
 RUN git clone https://github.com/CSUN-SeniorDesign/eat-blog.git
 
 # Pre hugo configuration
-RUN hugo new site beats
-RUN mv /eat-blog/arabica /beats/themes/arabica
-RUN rm -rf /beats/themes/arabica/exampleSite/*
-RUN mv /eat-blog/config.toml /beats/config.toml
-RUN mkdir /beats/content/post/
-RUN mv /eat-blog/* /beats/content/post/
-
+RUN hugo new site beats && \
+mv /eat-blog/arabica /beats/themes/arabica && \
+rm -rf /beats/themes/arabica/exampleSite/* && \
+mv /eat-blog/config.toml /beats/config.toml && \
+mkdir /beats/content/post/ && \
+mv /eat-blog/* /beats/content/post/ && \
 # Pre hugo clean up
-RUN rm /beats/content/post/BEATS-Uploader.py
-RUN rm /beats/content/post/ProductionSite.txt
-RUN rm /beats/content/post/S3-Fetch.py
-
+rm /beats/content/post/BEATS-Uploader.py && \
+rm /beats/content/post/ProductionSite.txt && \
+rm /beats/content/post/S3-Fetch.py && \
+rm -rf eat-blog && \
 # Use hugo to create the website
-RUN cd /beats && hugo
-
+cd /beats && hugo && \
 # Move the website to /var/www/html
-RUN mv /beats/public/* /var/www/html
+mv /beats/public/* /var/www/html && \
+rm -rf beats
+
 EXPOSE 80/tcp
 EXPOSE 443/tcp
 
 # Start apache2 service
-RUN sudo service apache2 start
+RUN service apache2 start
 
 # Change apache2's configuration to include 2 headers
-RUN a2enmod headers
-#RUN service apache2 restart
-RUN curl icanhazip.com | sudo tee /etc/apache2/serverip
-RUN echo "export servername=`</etc/hostname`" | sudo tee -a /etc/apache2/envvars
-RUN sudo echo "export serverip=`</etc/apache2/serverip`" | sudo tee -a /etc/apache2/envvars
-RUN echo "PassEnv servername" >> /etc/apache2/apache2.conf
-RUN echo "PassEnv serverip" >> /etc/apache2/apache2.conf
-RUN echo "Header set X-Hostname %{servername}e" >> /etc/apache2/apache2.conf
-RUN echo "Header set X-Private-IP %{serverip}e" >> /etc/apache2/apache2.conf
-#RUN service apache2 restart
+RUN a2enmod headers && \
+curl icanhazip.com | tee /etc/apache2/serverip && \
+echo "export servername=`</etc/hostname`" | tee -a /etc/apache2/envvars && \
+echo "export serverip=`</etc/apache2/serverip`" | tee -a /etc/apache2/envvars && \
+echo "PassEnv servername" >> /etc/apache2/apache2.conf && \
+echo "PassEnv serverip" >> /etc/apache2/apache2.conf && \
+echo "Header set X-Hostname %{servername}e" >> /etc/apache2/apache2.conf && \
+echo "Header set X-Private-IP %{serverip}e" >> /etc/apache2/apache2.conf
 
 # Move the script from the host to the image that installs datadog.
 COPY datadog.sh /home/datadog.sh
 RUN chmod 777 /home/datadog.sh
 
 # Link datadog to the image for monitoring.
-RUN sudo ./home/datadog.sh
+# RUN ./home/datadog.sh
 
 CMD service apache2 start && tail -f /dev/null


### PR DESCRIPTION
Originally fa480.club dockerfile created a 440MB image, now 265MB
Originally production-site dockerfile created a 870MB image, now 335MB